### PR TITLE
Fix typo in german language name in dropdown

### DIFF
--- a/src/languages/german.json
+++ b/src/languages/german.json
@@ -1,5 +1,5 @@
 {
-  "name":"Deutsche",
+  "name":"Deutsch",
 
   "methods":[
     {"name":"plural_s", "args":"n = 1", "body":"return parseInt(n) === 1 ? '' : 's'"},


### PR DESCRIPTION
Looks terrible in the dropdown, not sure how that happened, only noticed recently unfortunately.